### PR TITLE
Idn handshake

### DIFF
--- a/lib/SEC_Node_Statem.ex
+++ b/lib/SEC_Node_Statem.ex
@@ -97,7 +97,8 @@ defmodule SEC_Node_Statem do
       error: false,
       state: :disconnected,
       manual: opts[:manual] || false,
-      last_seen_update_ts: nil
+      last_seen_update_ts: nil,
+      idn: nil
     }
 
     Logger.info("Starting SEC Node State Machine for: #{opts[:host]}:#{opts[:port]}")
@@ -221,59 +222,74 @@ defmodule SEC_Node_Statem do
         :connected,
         %{node_id: node_id, description: description} = state
       ) do
-    # TODO IDN
+    case send_idn_message(node_id) do
+      {:ok, idn} ->
+        Logger.info("IDN handshake successful: #{idn.version}")
+        state = %{state | idn: idn}
 
-    Logger.info("Initial Describe Message sent")
+        Logger.info("Initial Describe Message sent")
 
-    case send_describe_message(node_id) do
-      {:ok, _specifier, parsed_description, raw_description} ->
-        equipment_id = parsed_description[:properties][:equipment_id]
+        case send_describe_message(node_id) do
+          {:ok, _specifier, parsed_description, raw_description} ->
+            equipment_id = parsed_description[:properties][:equipment_id]
 
-        case MapDiff.diff(parsed_description, description) do
-          # Notihng changed, probably just a prior network disconnect
-          %{changed: :equal, value: _} ->
-            Logger.info("Descriptive data constant --> connected & initialized")
-            updated_state = %{state | state: :initialized}
+            case MapDiff.diff(parsed_description, description) do
+              # Nothing changed, probably just a prior network disconnect
+              %{changed: :equal, value: _} ->
+                Logger.info("Descriptive data constant --> connected & initialized")
+                updated_state = %{state | state: :initialized}
+                publish_statechange(updated_state, state.pubsub_topic)
+
+                {:next_state, :initialized, updated_state,
+                 [
+                   {:next_event, :internal, :activate},
+                   {{:timeout, :inactivity_check}, @inactivity_timeout, nil}
+                 ]}
+
+              # Description changed update uuid, equipment_id and description
+              _ ->
+                Logger.info(
+                  "Descriptive data changed issuing new uuid --> connected & initialized"
+                )
+
+                updated_state_descr = %{
+                  state
+                  | description: parsed_description,
+                    raw_description: raw_description,
+                    uuid: Ecto.UUID.generate(),
+                    equipment_id: equipment_id,
+                    state: :initialized
+                }
+
+                updated_state_descr = %{updated_state_descr | state: :initialized}
+                publish_descriptive_data_change(updated_state_descr, state.pubsub_topic)
+                publish_statechange(updated_state_descr, state.pubsub_topic)
+
+                {:next_state, :initialized, updated_state_descr,
+                 [
+                   {:next_event, :internal, :activate},
+                   {{:timeout, :inactivity_check}, @inactivity_timeout, nil}
+                 ]}
+            end
+
+          {:error, _} ->
+            Logger.warning(
+              "NO answer on describe message for #{elem(node_id, 0)}:#{elem(node_id, 1)}, going into ERROR state"
+            )
+
+            updated_state = %{state | state: :could_not_initialize}
             publish_statechange(updated_state, state.pubsub_topic)
-
-            {:next_state, :initialized, updated_state,
-             [
-               {:next_event, :internal, :activate},
-               {{:timeout, :inactivity_check}, @inactivity_timeout, nil}
-             ]}
-
-          # Description changed update uuid, equipment_id and description
-          _ ->
-            Logger.info("Descriptive data changed issuing new uuid --> connected & initialized")
-
-            updated_state_descr = %{
-              state
-              | description: parsed_description,
-                raw_description: raw_description,
-                uuid: Ecto.UUID.generate(),
-                equipment_id: equipment_id,
-                state: :initialized
-            }
-
-            updated_state_descr = %{updated_state_descr | state: :initialized}
-            publish_descriptive_data_change(updated_state_descr, state.pubsub_topic)
-            publish_statechange(updated_state_descr, state.pubsub_topic)
-
-            {:next_state, :initialized, updated_state_descr,
-             [
-               {:next_event, :internal, :activate},
-               {{:timeout, :inactivity_check}, @inactivity_timeout, nil}
-             ]}
+            {:next_state, :could_not_initialize, updated_state}
         end
 
-      {:error, _} ->
+      {:error, :timeout} ->
         Logger.warning(
-          "NO answer on describe message for #{elem(node_id, 0)}:#{elem(node_id, 1)}, going into ERROR state"
+          "IDN timed out for #{elem(node_id, 0)}:#{elem(node_id, 1)}, going into ERROR state"
         )
 
         updated_state = %{state | state: :could_not_initialize}
         publish_statechange(updated_state, state.pubsub_topic)
-        {:next_state, :could_not_initialize, state}
+        {:next_state, :could_not_initialize, updated_state}
     end
   end
 
@@ -290,7 +306,7 @@ defmodule SEC_Node_Statem do
   end
 
   def handle_event({:call, from}, :get_state, state_name, state)
-      when state_name in [:initialized, :connected, :disconnected, :connecting] do
+      when state_name in [:initialized, :connected, :disconnected, :connecting, :could_not_initialize] do
     {:keep_state_and_data, {:reply, from, {:ok, state}}}
   end
 
@@ -608,6 +624,16 @@ defmodule SEC_Node_Statem do
       )
 
       @tcp_module.disconnect(node_id)
+    end
+  end
+
+  defp send_idn_message(node_id) do
+    @tcp_module.send_message(node_id, ~c"*IDN?\n")
+
+    receive do
+      {:identification, %SECoP_IDN{} = idn} -> {:ok, idn}
+    after
+      @handshake_timeout -> {:error, :timeout}
     end
   end
 

--- a/lib/SECoP_IDN.ex
+++ b/lib/SECoP_IDN.ex
@@ -1,0 +1,3 @@
+defmodule SECoP_IDN do
+  defstruct [:manufacturer, :product, :draft_date, :version]
+end

--- a/lib/SECoP_Parser.ex
+++ b/lib/SECoP_Parser.ex
@@ -8,53 +8,35 @@ defmodule SECoP_Parser do
     trimmed = String.trim(message)
 
 
-
-    if String.starts_with?(trimmed, "ISSE,SECoP,") do
-      idn(node_id, trimmed)
-    else
-      parse_secop(node_id, trimmed)
-    end
-  end
-
-  defp parse_secop(node_id, trimmed) do
+    # SECoP message are of the form
+    # messge_code specifier data
     split_message = String.split(trimmed, " ", parts: 3)
 
-    # Handle Error Reports:
-    if length(split_message) == 3 and String.starts_with?(hd(split_message), "error_") do
-      [error_message, specifier, data] = split_message
+    case split_message do
+      ["update", specifier, data] -> update(node_id, specifier, data)
+      ["describing", specifier, data] -> describe(node_id, specifier, data)
+      ["inactive"] -> inactive(node_id)
+      ["pong", id, data] -> pong(node_id, id, data)
+      ["active"] -> active(node_id)
+      ["reply", specifier, data] -> reply(node_id, specifier, data)
+      ["changed", specifier, data] -> changed(node_id, specifier, data)
+      ["done", specifier, data] -> done(node_id, specifier, data)
+      ["error_update",specifier,data] -> error_update(node_id, specifier, data)
+      ["error_describe",specifier,data] -> error_response(:error_describe, node_id, specifier, data)
+      ["error_deactivate",specifier,data] -> error_response(:error_deactivate, node_id, specifier, data)
+      ["error_ping",specifier,data] -> error_response(:error_ping, node_id, specifier, data)
+      ["error_activate",specifier,data] -> error_response(:error_activate, node_id, specifier, data)
+      ["error_read",specifier,data] -> error_response(:error_read, node_id, specifier, data)
+      ["error_change",specifier,data] -> error_response(:error_change, node_id, specifier, data)
+      ["error_do",specifier,data] -> error_response(:error_do, node_id, specifier, data)
+      ["ISSE,SECoP," <> _ = idn] -> idn(node_id, idn)
+      _ -> Logger.warning("Unknown message received: #{trimmed}")
 
-      Logger.error(
-        "Error message received: #{error_message}, specifier: #{specifier}, data: #{data}"
-      )
-
-      {:ok, data} = Jason.decode(data, keys: :atoms)
-
-      case error_message do
-        "error_update" -> error_update(node_id, specifier, data)
-        "error_describe" -> error_response(:error_describe, node_id, specifier, data)
-        "error_deactivate" -> error_response(:error_deactivate, node_id, specifier, data)
-        "error_ping" -> error_response(:error_ping, node_id, specifier, data)
-        "error_activate" -> error_response(:error_activate, node_id, specifier, data)
-        "error_read" -> error_response(:error_read, node_id, specifier, data)
-        "error_change" -> error_response(:error_change, node_id, specifier, data)
-        "error_do" -> error_response(:error_do, node_id, specifier, data)
-        _ -> Logger.warning("Unknown error message received: #{trimmed}")
-      end
-    else
-      # Handle all Normal SECoP Messages:
-      case split_message do
-        ["update", specifier, data] -> update(node_id, specifier, data)
-        ["describing", specifier, data] -> describe(node_id, specifier, data)
-        ["inactive"] -> inactive(node_id)
-        ["pong", id, data] -> pong(node_id, id, data)
-        ["active"] -> active(node_id)
-        ["reply", specifier, data] -> reply(node_id, specifier, data)
-        ["changed", specifier, data] -> changed(node_id, specifier, data)
-        ["done", specifier, data] -> done(node_id, specifier, data)
-        _ -> Logger.warning("Unknown message received: #{trimmed}")
-      end
     end
+
+
   end
+
 
   defp idn(node_id, idn_string) do
     Logger.debug("IDN response received: #{idn_string}")
@@ -251,7 +233,9 @@ defmodule SECoP_Parser do
     parsed_module_description
   end
 
-  def error_update(node_id, specifier, error_report) do
+  def error_update(node_id, specifier, data) do
+    {:ok, error_report} = Jason.decode(data, keys: :atoms)
+
     Logger.warning(
       "Error update message received. Specifier: #{specifier}, Data: #{inspect(error_report)}"
     )
@@ -272,7 +256,8 @@ defmodule SECoP_Parser do
     )
   end
 
-  def error_response(error_code, node_id, specifier, error_report) do
+  def error_response(error_code, node_id, specifier, data) do
+    {:ok, error_report} = Jason.decode(data, keys: :atoms)
     error_class = Enum.at(error_report, 0)
     error_text = Enum.at(error_report, 1)
     error_dict = Enum.at(error_report, 2)

--- a/lib/SECoP_Parser.ex
+++ b/lib/SECoP_Parser.ex
@@ -5,7 +5,19 @@ defmodule SECoP_Parser do
   alias Jason
 
   def parse(node_id, message) do
-    split_message = String.trim(message) |> String.split(" ", parts: 3)
+    trimmed = String.trim(message)
+
+
+
+    if String.starts_with?(trimmed, "ISSE,SECoP,") do
+      idn(node_id, trimmed)
+    else
+      parse_secop(node_id, trimmed)
+    end
+  end
+
+  defp parse_secop(node_id, trimmed) do
+    split_message = String.split(trimmed, " ", parts: 3)
 
     # Handle Error Reports:
     if length(split_message) == 3 and String.starts_with?(hd(split_message), "error_") do
@@ -26,7 +38,7 @@ defmodule SECoP_Parser do
         "error_read" -> error_response(:error_read, node_id, specifier, data)
         "error_change" -> error_response(:error_change, node_id, specifier, data)
         "error_do" -> error_response(:error_do, node_id, specifier, data)
-        _ -> Logger.warning("Unknown error message received: #{message}")
+        _ -> Logger.warning("Unknown error message received: #{trimmed}")
       end
     else
       # Handle all Normal SECoP Messages:
@@ -39,9 +51,25 @@ defmodule SECoP_Parser do
         ["reply", specifier, data] -> reply(node_id, specifier, data)
         ["changed", specifier, data] -> changed(node_id, specifier, data)
         ["done", specifier, data] -> done(node_id, specifier, data)
-        _ -> Logger.warning("Unknown message received: #{message}")
+        _ -> Logger.warning("Unknown message received: #{trimmed}")
       end
     end
+  end
+
+  defp idn(node_id, idn_string) do
+    Logger.debug("IDN response received: #{idn_string}")
+    [manufacturer, product, draft_date, version] = String.split(idn_string, ",", parts: 4)
+
+    struct = %SECoP_IDN{
+      manufacturer: manufacturer,
+      product: product,
+      draft_date: draft_date,
+      version: version
+    }
+
+    Registry.dispatch(Registry.SEC_Node_Statem, node_id, fn entries ->
+      for {pid, _value} <- entries, do: send(pid, {:identification, struct})
+    end)
   end
 
   defp splitSpecifier(specifier) do

--- a/test/sec_node_statem_test.exs
+++ b/test/sec_node_statem_test.exs
@@ -65,6 +65,14 @@ defmodule SECNodeStatemTest do
   # Called from within the gen_statem process (self() == statem pid).
   defp auto_respond(charlist) do
     case to_string(charlist) do
+      "*IDN?\n" ->
+        send(self(), {:identification, %SECoP_IDN{
+          manufacturer: "ISSE",
+          product: "SECoP",
+          draft_date: "",
+          version: "V2024-09-19"
+        }})
+
       "describe .\n" ->
         send(self(), {:describe, ".", minimal_description(), %{}})
 
@@ -303,6 +311,14 @@ defmodule SECNodeStatemTest do
 
       stub(MockTcpConnection, :send_message, fn _id, charlist ->
         case to_string(charlist) do
+          "*IDN?\n" ->
+            send(self(), {:identification, %SECoP_IDN{
+              manufacturer: "ISSE",
+              product: "SECoP",
+              draft_date: "",
+              version: "V2024-09-19"
+            }})
+
           <<"ping ", rest::binary>> ->
             if :counters.get(describe_count, 1) == 0 do
               # First inactivity ping: simulate drop+reconnect while the
@@ -403,6 +419,44 @@ defmodule SECNodeStatemTest do
       # After reconnect_timeout (50 ms) the timer fires, is_connected returns
       # true, and the handshake completes.
       assert wait_for_state(ctx.node_id, :initialized, 2_000) == :ok
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # IDN handshake
+  # ---------------------------------------------------------------------------
+
+  describe "IDN handshake" do
+    test "sends *IDN? as first handshake message and stores parsed struct in state", ctx do
+      stub(MockTcpConnection, :is_connected, fn _id -> true end)
+      test_pid = self()
+
+      stub(MockTcpConnection, :send_message, fn _id, cl ->
+        if to_string(cl) == "*IDN?\n", do: send(test_pid, :idn_sent)
+        auto_respond(cl)
+        :ok
+      end)
+
+      start_statem(ctx)
+      assert_receive :idn_sent, 1_000
+      :ok = wait_for_state(ctx.node_id, :initialized, 1_000)
+
+      assert get_state_data(ctx.node_id).idn == %SECoP_IDN{
+               manufacturer: "ISSE",
+               product: "SECoP",
+               draft_date: "",
+               version: "V2024-09-19"
+             }
+    end
+
+    test "transitions to :could_not_initialize when IDN times out", ctx do
+      stub(MockTcpConnection, :is_connected, fn _id -> true end)
+      # send_message responds to nothing — IDN will time out
+      stub(MockTcpConnection, :send_message, fn _id, _msg -> :ok end)
+
+      start_statem(ctx)
+      # handshake_timeout in test config is 500 ms
+      assert wait_for_state(ctx.node_id, :could_not_initialize, 2_000) == :ok
     end
   end
 end


### PR DESCRIPTION

## Summary

- Add `SECoP_IDN` struct and parse IDN identification responses (`ISSE,SECoP,...`) via binary pattern matching directly in the main `case` dispatch
- Refactor parser dispatch: replace the two-branch `if/case` (error vs. normal) with a single flat `case`, handling all message types uniformly
- Fix `error_update/3` and `error_response/4` to decode JSON internally, consistent with all other handlers — previously they expected pre-decoded data but received raw strings

## Test plan

- [x] Run `mix test` — existing suite passes
- [x] Connect to a live SECoP node and verify `ISSE,SECoP,...` IDN string triggers `{:identification, %SECoP_IDN{}}` message to the statem
- [x] Trigger an error response (e.g. `error_read`) from the node and confirm the statem receives `{:error_read, specifier, class, text, dict}` with correctly decoded fields

