### PR TITLE
repo rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-secop_client-*.tar
+secant_client-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# SecopClient
+# SecantClient
 
 **TODO: Add description**
 
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `secop_client` to your list of dependencies in `mix.exs`:
+by adding `secant_client` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:secop_client, "~> 0.1.0"}
+    {:secant_client, "~> 0.1.0"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/secop_client>.
+be found at <https://hexdocs.pm/secant_client>.
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 import Config
 
-config :secop_client,
+config :secant_client,
   tcp_connection_module: MockTcpConnection,
   inactivity_timeout: 100,
   reconnect_timeout: 50,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
 
-  secop_client:
+  secant_client:
     build: .
     restart: always
     network_mode: host

--- a/lib/SEC_Node_Statem.ex
+++ b/lib/SEC_Node_Statem.ex
@@ -7,11 +7,11 @@ defmodule SEC_Node_Statem do
   @behaviour :gen_statem
 
   @initial_state :connecting
-  @tcp_module Application.compile_env(:secop_client, :tcp_connection_module, TcpConnection)
-  @inactivity_timeout Application.compile_env(:secop_client, :inactivity_timeout, 15_000)
-  @reconnect_timeout Application.compile_env(:secop_client, :reconnect_timeout, 5_000)
-  @call_timeout Application.compile_env(:secop_client, :call_timeout, 5_000)
-  @handshake_timeout Application.compile_env(:secop_client, :handshake_timeout, 15_000)
+  @tcp_module Application.compile_env(:secant_client, :tcp_connection_module, TcpConnection)
+  @inactivity_timeout Application.compile_env(:secant_client, :inactivity_timeout, 15_000)
+  @reconnect_timeout Application.compile_env(:secant_client, :reconnect_timeout, 5_000)
+  @call_timeout Application.compile_env(:secant_client, :call_timeout, 5_000)
+  @handshake_timeout Application.compile_env(:secant_client, :handshake_timeout, 15_000)
 
   # Public
   def start_link(opts) do
@@ -673,7 +673,7 @@ defmodule SEC_Node_Statem do
     Logger.debug("publish descriptive data change for #{pubsub_topic}")
 
     Phoenix.PubSub.broadcast(
-      :secop_client_pubsub,
+      :secant_client_pubsub,
       "descriptive_data_change",
       {:description_change, pubsub_topic, state}
     )
@@ -683,7 +683,7 @@ defmodule SEC_Node_Statem do
     Logger.debug("publish conn state change for #{pubsub_topic} connection is active: #{active}")
 
     Phoenix.PubSub.broadcast(
-      :secop_client_pubsub,
+      :secant_client_pubsub,
       "secop_conn_state",
       {:conn_state, pubsub_topic, active}
     )
@@ -693,7 +693,7 @@ defmodule SEC_Node_Statem do
     Logger.debug("publish statechange for #{pubsub_topic} --> #{state.state}")
 
     Phoenix.PubSub.broadcast(
-      :secop_client_pubsub,
+      :secant_client_pubsub,
       "state_change",
       {:state_change, pubsub_topic, state}
     )
@@ -703,7 +703,7 @@ defmodule SEC_Node_Statem do
     Logger.debug("publish new node added at: #{pubsub_topic}")
 
     Phoenix.PubSub.broadcast(
-      :secop_client_pubsub,
+      :secant_client_pubsub,
       "new_node",
       {:new_node, pubsub_topic, state}
     )

--- a/lib/SECoP_Parser.ex
+++ b/lib/SECoP_Parser.ex
@@ -74,7 +74,7 @@ defmodule SECoP_Parser do
       )
 
     Phoenix.PubSub.broadcast(
-      :secop_client_pubsub,
+      :secant_client_pubsub,
       "value_update:#{elem(node_id, 0)}:#{elem(node_id, 1)}",
       {:value_update, module, accessible, data_report}
     )
@@ -250,7 +250,7 @@ defmodule SECoP_Parser do
       )
 
     Phoenix.PubSub.broadcast(
-      :secop_client_pubsub,
+      :secant_client_pubsub,
       "error_update:#{elem(node_id, 0)}:#{elem(node_id, 1)}",
       {:error_update, module, accessible, error_report}
     )

--- a/lib/mix/tasks/client.ex
+++ b/lib/mix/tasks/client.ex
@@ -1,9 +1,9 @@
 defmodule Mix.Tasks.Client do
   use Mix.Task
-  alias SecopClient
+  alias SecantClient
   alias SEC_Node_Supervisor
 
-  @shortdoc "Starts the SecopClient application and runs indefinitely"
+  @shortdoc "Starts the SecantClient application and runs indefinitely"
 
   def run(_args) do
     Mix.Task.run("app.start")

--- a/lib/secant_client.ex
+++ b/lib/secant_client.ex
@@ -1,5 +1,5 @@
-defmodule SecopClient do
-  # alias SecopClient.UdpBroadcaster
+defmodule SecantClient do
+  # alias SecantClient.UdpBroadcaster
   alias NodeDiscover
   alias NodeTable
   alias TcpConnection
@@ -11,7 +11,7 @@ defmodule SecopClient do
     :ok = NodeTable.init_lookup_table()
 
     base_children = [
-      {Phoenix.PubSub, name: :secop_client_pubsub},
+      {Phoenix.PubSub, name: :secant_client_pubsub},
       {Registry, keys: :unique, name: Registry.Buffer},
       {Registry, keys: :unique, name: Registry.TcpConnection},
       {Registry, keys: :unique, name: Registry.SEC_Node_Statem},
@@ -21,13 +21,13 @@ defmodule SecopClient do
     ]
 
     children =
-      if Application.get_env(:secop_client, :start_node_discover, true) do
+      if Application.get_env(:secant_client, :start_node_discover, true) do
         base_children ++ [{NodeDiscover, &SEC_Node_Supervisor.start_child_from_discovery/3}]
       else
         base_children
       end
 
-    opts = [strategy: :one_for_one, name: SecopClient.Supervisor]
+    opts = [strategy: :one_for_one, name: SecantClient.Supervisor]
 
     Supervisor.start_link(children, opts)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -1,9 +1,9 @@
-defmodule SecopClient.MixProject do
+defmodule SecantClient.MixProject do
   use Mix.Project
 
   def project do
     [
-      app: :secop_client,
+      app: :secant_client,
       version: "0.1.0",
       elixir: "~> 1.17",
       start_permanent: Mix.env() == :prod,
@@ -18,7 +18,7 @@ defmodule SecopClient.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      mod: {SecopClient, []},
+      mod: {SecantClient, []},
       extra_applications: [:logger]
     ]
   end


### PR DESCRIPTION
## Rename package from `secop_client` to `secant_client`

Reflects the repository rename from `secop_client` to `secant-client`. Since hyphens are not valid in Elixir package names, the internal package name uses an underscore: `secant_client`.

### Changes
- Rename `lib/secop_client.ex` → `lib/secant_client.ex`; update module name `SecopClient` → `SecantClient`
- Update application atom `:secop_client` → `:secant_client` across `mix.exs`, `config/test.exs`, and all `Application.compile_env/get_env` call sites
- Rename PubSub instance `:secop_client_pubsub` → `:secant_client_pubsub` in `SEC_Node_Statem.ex` and `SECoP_Parser.ex`
- Update `docker-compose.yml` service name and `.gitignore` build artifact pattern
- Update `README.md` package name and HexDocs URL

> **Note:** SECoP protocol-level identifiers (e.g. `publish_secop_conn_state`, topic `"secop_conn_state"`) are intentionally unchanged — they refer to the SECoP protocol, not the package name.