### PR TITLE
secant client supervisor

### DIFF
--- a/lib/SEC_Node_Statem.ex
+++ b/lib/SEC_Node_Statem.ex
@@ -306,7 +306,13 @@ defmodule SEC_Node_Statem do
   end
 
   def handle_event({:call, from}, :get_state, state_name, state)
-      when state_name in [:initialized, :connected, :disconnected, :connecting, :could_not_initialize] do
+      when state_name in [
+             :initialized,
+             :connected,
+             :disconnected,
+             :connecting,
+             :could_not_initialize
+           ] do
     {:keep_state_and_data, {:reply, from, {:ok, state}}}
   end
 

--- a/lib/SECoP_Parser.ex
+++ b/lib/SECoP_Parser.ex
@@ -7,37 +7,69 @@ defmodule SECoP_Parser do
   def parse(node_id, message) do
     trimmed = String.trim(message)
 
-
     # SECoP message are of the form
     # messge_code specifier data
     split_message = String.split(trimmed, " ", parts: 3)
 
     case split_message do
-      ["update", specifier, data] -> update(node_id, specifier, data)
-      ["describing", specifier, data] -> describe(node_id, specifier, data)
-      ["inactive"] -> inactive(node_id)
-      ["pong", id, data] -> pong(node_id, id, data)
-      ["active"] -> active(node_id)
-      ["reply", specifier, data] -> reply(node_id, specifier, data)
-      ["changed", specifier, data] -> changed(node_id, specifier, data)
-      ["done", specifier, data] -> done(node_id, specifier, data)
-      ["error_update",specifier,data] -> error_update(node_id, specifier, data)
-      ["error_describe",specifier,data] -> error_response(:error_describe, node_id, specifier, data)
-      ["error_deactivate",specifier,data] -> error_response(:error_deactivate, node_id, specifier, data)
-      ["error_ping",specifier,data] -> error_response(:error_ping, node_id, specifier, data)
-      ["error_activate",specifier,data] -> error_response(:error_activate, node_id, specifier, data)
-      ["error_read",specifier,data] -> error_response(:error_read, node_id, specifier, data)
-      ["error_change",specifier,data] -> error_response(:error_change, node_id, specifier, data)
-      ["error_do",specifier,data] -> error_response(:error_do, node_id, specifier, data)
-      ["ISSE,SECoP," <> _ = idn] -> idn(node_id, idn)
-      ["ISSE&SINE2020,SECoP," <> _ = idn] -> idn(node_id, idn)
-      _ -> Logger.warning("Unknown message received: #{trimmed}")
+      ["update", specifier, data] ->
+        update(node_id, specifier, data)
 
+      ["describing", specifier, data] ->
+        describe(node_id, specifier, data)
+
+      ["inactive"] ->
+        inactive(node_id)
+
+      ["pong", id, data] ->
+        pong(node_id, id, data)
+
+      ["active"] ->
+        active(node_id)
+
+      ["reply", specifier, data] ->
+        reply(node_id, specifier, data)
+
+      ["changed", specifier, data] ->
+        changed(node_id, specifier, data)
+
+      ["done", specifier, data] ->
+        done(node_id, specifier, data)
+
+      ["error_update", specifier, data] ->
+        error_update(node_id, specifier, data)
+
+      ["error_describe", specifier, data] ->
+        error_response(:error_describe, node_id, specifier, data)
+
+      ["error_deactivate", specifier, data] ->
+        error_response(:error_deactivate, node_id, specifier, data)
+
+      ["error_ping", specifier, data] ->
+        error_response(:error_ping, node_id, specifier, data)
+
+      ["error_activate", specifier, data] ->
+        error_response(:error_activate, node_id, specifier, data)
+
+      ["error_read", specifier, data] ->
+        error_response(:error_read, node_id, specifier, data)
+
+      ["error_change", specifier, data] ->
+        error_response(:error_change, node_id, specifier, data)
+
+      ["error_do", specifier, data] ->
+        error_response(:error_do, node_id, specifier, data)
+
+      ["ISSE,SECoP," <> _ = idn] ->
+        idn(node_id, idn)
+
+      ["ISSE&SINE2020,SECoP," <> _ = idn] ->
+        idn(node_id, idn)
+
+      _ ->
+        Logger.warning("Unknown message received: #{trimmed}")
     end
-
-
   end
-
 
   defp idn(node_id, idn_string) do
     Logger.debug("IDN response received: #{idn_string}")

--- a/lib/secant_client.ex
+++ b/lib/secant_client.ex
@@ -1,34 +1,7 @@
 defmodule SecantClient do
-  # alias SecantClient.UdpBroadcaster
-  alias NodeDiscover
-  alias NodeTable
-  alias TcpConnection
-  alias Buffer
-  alias SEC_Node_Statem
   use Application
 
   def start(_type, _args) do
-    :ok = NodeTable.init_lookup_table()
-
-    base_children = [
-      {Phoenix.PubSub, name: :secant_client_pubsub},
-      {Registry, keys: :unique, name: Registry.Buffer},
-      {Registry, keys: :unique, name: Registry.TcpConnection},
-      {Registry, keys: :unique, name: Registry.SEC_Node_Statem},
-      {Registry, keys: :unique, name: Registry.SecNodePublisher},
-      {Registry, keys: :unique, name: Registry.SEC_Node_Services},
-      {SEC_Node_Supervisor, []}
-    ]
-
-    children =
-      if Application.get_env(:secant_client, :start_node_discover, true) do
-        base_children ++ [{NodeDiscover, &SEC_Node_Supervisor.start_child_from_discovery/3}]
-      else
-        base_children
-      end
-
-    opts = [strategy: :one_for_one, name: SecantClient.Supervisor]
-
-    Supervisor.start_link(children, opts)
+    SecantClient.Supervisor.start_link(name: SecantClient.Supervisor)
   end
 end

--- a/lib/secant_client/supervisor.ex
+++ b/lib/secant_client/supervisor.ex
@@ -1,0 +1,37 @@
+defmodule SecantClient.Supervisor do
+  # alias SecantClient.UdpBroadcaster
+  alias NodeDiscover
+  alias NodeTable
+  alias TcpConnection
+  alias Buffer
+  alias SEC_Node_Statem
+  use Supervisor
+
+  def start_link(opts \\ []) do
+    Supervisor.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  @impl true
+  def init(_opts) do
+    :ok = NodeTable.init_lookup_table()
+
+    base_children = [
+      {Phoenix.PubSub, name: :secant_client_pubsub},
+      {Registry, keys: :unique, name: Registry.Buffer},
+      {Registry, keys: :unique, name: Registry.TcpConnection},
+      {Registry, keys: :unique, name: Registry.SEC_Node_Statem},
+      {Registry, keys: :unique, name: Registry.SecNodePublisher},
+      {Registry, keys: :unique, name: Registry.SEC_Node_Services},
+      {SEC_Node_Supervisor, []}
+    ]
+
+    children =
+      if Application.get_env(:secant_client, :start_node_discover, true) do
+        base_children ++ [{NodeDiscover, &SEC_Node_Supervisor.start_child_from_discovery/3}]
+      else
+        base_children
+      end
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+end

--- a/test/sec_node_statem_test.exs
+++ b/test/sec_node_statem_test.exs
@@ -66,12 +66,16 @@ defmodule SECNodeStatemTest do
   defp auto_respond(charlist) do
     case to_string(charlist) do
       "*IDN?\n" ->
-        send(self(), {:identification, %SECoP_IDN{
-          manufacturer: "ISSE",
-          product: "SECoP",
-          draft_date: "",
-          version: "V2024-09-19"
-        }})
+        send(
+          self(),
+          {:identification,
+           %SECoP_IDN{
+             manufacturer: "ISSE",
+             product: "SECoP",
+             draft_date: "",
+             version: "V2024-09-19"
+           }}
+        )
 
       "describe .\n" ->
         send(self(), {:describe, ".", minimal_description(), %{}})
@@ -312,12 +316,16 @@ defmodule SECNodeStatemTest do
       stub(MockTcpConnection, :send_message, fn _id, charlist ->
         case to_string(charlist) do
           "*IDN?\n" ->
-            send(self(), {:identification, %SECoP_IDN{
-              manufacturer: "ISSE",
-              product: "SECoP",
-              draft_date: "",
-              version: "V2024-09-19"
-            }})
+            send(
+              self(),
+              {:identification,
+               %SECoP_IDN{
+                 manufacturer: "ISSE",
+                 product: "SECoP",
+                 draft_date: "",
+                 version: "V2024-09-19"
+               }}
+            )
 
           <<"ping ", rest::binary>> ->
             if :counters.get(describe_count, 1) == 0 do


### PR DESCRIPTION
## Summary
Expose secant_client's supervision tree as `SecantClient.Supervisor`, a plain `Supervisor` that host applications can add directly to their own supervision tree, instead of it only being startable as an auto-started OTP application.

- `SecantClient.Supervisor` now owns the child list (registries, `SEC_Node_Supervisor`, optional `NodeDiscover`) that previously lived inline in `SecantClient.start/2`.
- `SecantClient` (the `Application` callback) is now a thin delegate to `SecantClient.Supervisor.start_link/1`, so standalone/auto-started usage (`mod: {SecantClient, []}`) is unchanged.

## Test plan
- [x] `mix compile`
- [x] `mix test` (21 tests, 0 failures)
